### PR TITLE
[REVIEW][FIX[UWANG-195] - Sign Up OTP verification button when the OTP is entered incorrectly should be disabled

### DIFF
--- a/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/SignUpEffect.kt
+++ b/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/SignUpEffect.kt
@@ -12,5 +12,4 @@ sealed interface SignUpEffect {
     object None : SignUpEffect
 
     object NavigateToPersonalize : SignUpEffect
-    object NavigateToMain : SignUpEffect
 }

--- a/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/SignUpScreen.kt
+++ b/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/SignUpScreen.kt
@@ -70,15 +70,6 @@ fun SignUpScreen(
                     }
                 }
             }
-
-            SignUpEffect.NavigateToMain -> {
-                navHostController.navigate(Routes.Home) {
-                    launchSingleTop = true
-                    popUpTo(Routes.SignUp){
-                        inclusive = true
-                    }
-                }
-            }
         }
     })
 

--- a/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/SignUpViewModel.kt
+++ b/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/SignUpViewModel.kt
@@ -44,7 +44,13 @@ class SignUpViewModel @Inject constructor(
             is SignUpAction.OnPasswordChange -> onPasswordChange(action.value)
             is SignUpAction.OnPasswordConfirmationChange -> onPasswordConfirmationChange(action.value)
             is SignUpAction.OnOtpChange -> {
-                updateState { copy(otpNumberState = action.value, otpNumberInputState = TextFieldState.None) }
+                updateState {
+                    copy(
+                        otpNumberState = action.value,
+                        otpNumberInputState = TextFieldState.None,
+                        verifyOtpButtonEnabled = true
+                    )
+                }
                 if (action.value.length == 4) {
                     verifyOtp()
                 }
@@ -181,7 +187,8 @@ class SignUpViewModel @Inject constructor(
                         updateState {
                             copy(
                                 otpNumberInputState = TextFieldState.Error(it.message),
-                                otpAttempt = (otp + 1)
+                                otpAttempt = (otp + 1),
+                                verifyOtpButtonEnabled = false
                             )
                         }
                     }
@@ -228,7 +235,7 @@ class SignUpViewModel @Inject constructor(
                     }
 
                     is Response.Result -> {
-                        sendEffect(SignUpEffect.NavigateToMain)
+                        sendEffect(SignUpEffect.NavigateToPersonalize)
                     }
                 }
             }
@@ -261,7 +268,6 @@ class SignUpViewModel @Inject constructor(
                                 otpSentAlertVisibility = true
                             )
                         }
-                        sendEffect(SignUpEffect.NavigateToPersonalize)
                     }
                 }
             }

--- a/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/screen/OtpSignUpScreen.kt
+++ b/androidApp/src/main/java/com/bluhabit/blu/android/presentation/authentication/signup/screen/OtpSignUpScreen.kt
@@ -179,7 +179,7 @@ fun OtpSignUpScreen(
                     .fillMaxWidth(),
                 text = stringResource(id = R.string.label_button_otp),
                 enabled = state.otpNumberState.length == 4
-                        && state.otpAttempt < 4
+                        && state.otpAttempt < 4 && state.verifyOtpButtonEnabled
             ) {
                 onAction(SignUpAction.OnVerifyOtp)
             }


### PR DESCRIPTION
#### Description

> fix: disabled verify OTP button when wrong attempt at sign up flow

#### Ticket Reference(s)

[UWANG-195](https://bluehabit.atlassian.net/browse/UWANG-195)

#### Validation

##### UI Changes

> Screenshot or video of UI-related changes

##### Coverage

> Test coverage screenshot.

N/A

#### Note(s)

> @triandamai @azkifairuz @Jocerdikiawann @WhyUReRenldI 


[UWANG-195]: https://bluehabit.atlassian.net/browse/UWANG-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ